### PR TITLE
fix: 개인 repository용 ruleset bypass actor 추가

### DIFF
--- a/devconfig/github/init-github-ruleset.py
+++ b/devconfig/github/init-github-ruleset.py
@@ -133,7 +133,13 @@ def create_or_update_ruleset(owner, repo, ruleset_id=None):
                 "parameters": {}
             }
         ],
-        "bypass_actors": []
+        "bypass_actors": [
+            {
+                "actor_type": "RepositoryRole",
+                "bypass_mode": "pull_request",
+                "actor_id": 5 # admin
+            }
+        ]
     }
     
     # JSON 파일로 임시 저장

--- a/devconfig/github/init-github-ruleset.py
+++ b/devconfig/github/init-github-ruleset.py
@@ -137,7 +137,7 @@ def create_or_update_ruleset(owner, repo, ruleset_id=None):
             {
                 "actor_type": "RepositoryRole",
                 "bypass_mode": "pull_request",
-                "actor_id": 5 # admin
+                "actor_id": 5 # repository admin
             }
         ]
     }


### PR DESCRIPTION
**Summary**

* 개인 repository에서 PR 검토자가 없어도 merge할 수 있도록 bypass actor 추가
* Repository admin 역할에 PR에서만 ruleset을 우회할 수 있는 권한 부여

**Changes**

* `bypass_actors`에 RepositoryRole admin (actor_id: 5) 추가
* `bypass_mode`를 `pull_request`로 설정하여 PR에서만 우회 가능
* 개인 repository 특성상 검토자가 없는 상황을 해결

**Test Plan**

* 기존 ruleset 업데이트 후 PR merge 가능 여부 확인
* bypass 권한이 올바르게 적용되는지 검증