### PR TITLE
feat: slack 부팅 알림 기능 추가

### DIFF
--- a/homelab/01-server-init/deploy.py
+++ b/homelab/01-server-init/deploy.py
@@ -25,7 +25,7 @@ def check_prerequisites():
     print("✅ vars/main.yml 파일 존재")
     
     # 플레이북 파일들 확인
-    playbooks = ["ubuntu-setup.yml", "wakeonlan-setup.yml", "k3s-install.yml"]
+    playbooks = ["ubuntu-setup.yml", "wakeonlan-setup.yml", "k3s-install.yml", "slack-alert.yml"]
     playbook_dir = Path(__file__).parent / "playbooks"
     
     for playbook in playbooks:
@@ -100,6 +100,7 @@ def main():
     print("- Ubuntu 24 초기설정 (APT 미러, SSH 보안, 타임존)")
     print("- WakeOnLAN 설정")
     print("- K3s 클러스터 설치")
+    print("- Slack 부팅 알림 설정 (webhook URL 설정시)")
     print("")
     
     # 사용자 확인
@@ -128,12 +129,16 @@ def main():
         if not run_playbook("k3s-install.yml", vars_file, "K3s 설치"):
             sys.exit(1)
         
+        # Slack 알림 설정 (실패해도 계속 진행)
+        run_playbook("slack-alert.yml", vars_file, "Slack 부팅 알림 설정")
+        
         print("\n🎉 홈랩 전체 설치가 성공적으로 완료되었습니다!")
         print("\n📋 다음 단계:")
         print("1. ~/.kube/homelab-config 파일이 생성되었습니다.")
         print("2. kubectl을 사용하여 클러스터에 접근할 수 있습니다:")
         print("   export KUBECONFIG=~/.kube/homelab-config")
         print("   kubectl get nodes")
+        print("3. 다음 부팅시부터 Slack 알림이 전송됩니다. (설정된 경우)")
         
     except KeyboardInterrupt:
         print("\n❌ 사용자에 의해 설치가 중단되었습니다")

--- a/homelab/01-server-init/files/homelab-boot-notify.service
+++ b/homelab/01-server-init/files/homelab-boot-notify.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Homelab Boot Notification Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/homelab-boot-notify.sh
+RemainAfterExit=yes
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/homelab/01-server-init/files/homelab-boot-notify.sh.j2
+++ b/homelab/01-server-init/files/homelab-boot-notify.sh.j2
@@ -1,0 +1,60 @@
+#!/bin/bash
+# 홈랩 서버 부팅 완료 Slack 알림 스크립트
+
+WEBHOOK_URL="{{ slack_webhook_url }}"
+
+# 현재 시간을 원하는 포맷으로 저장
+# 예: 2025년 08월 02일 15시 15분 08초
+CURRENT_TIME=$(date "+%Y년 %m월 %d일 %H시 %M분 %S초")
+
+# JSON 페이로드 생성
+# $CURRENT_TIME 변수를 JSON 내부의 문자열로 삽입
+JSON_PAYLOAD=$(cat <<EOF
+{
+    "attachments": [
+        {
+            "color": "#2EB67D",
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "🏠 홈랩 서버 부팅 완료",
+                        "emoji": true
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "서버가 성공적으로 시작되어 이제 사용 가능한 상태입니다. 🚀"
+                    }
+                },
+                {
+                    "type": "divider"
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": "부팅 완료 시간: $CURRENT_TIME"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+EOF
+)
+
+# curl을 사용하여 슬랙으로 POST 요청 전송
+curl -X POST -H 'Content-type: application/json' --data "$JSON_PAYLOAD" $WEBHOOK_URL
+
+if [ $? -eq 0 ]; then
+    echo "✅ Slack 알림이 성공적으로 전송되었습니다!"
+else
+    echo "❌ Slack 알림 전송에 실패했습니다."
+    exit 1
+fi

--- a/homelab/01-server-init/playbooks/slack-alert.yml
+++ b/homelab/01-server-init/playbooks/slack-alert.yml
@@ -1,0 +1,52 @@
+---
+- name: 홈랩 부팅 완료 Slack 알림 서비스 설정
+  hosts: homelab
+  become: yes
+
+  tasks:
+    - name: Slack 설정 확인
+      debug:
+        msg: "Slack Webhook URL이 설정되지 않아 Slack 알림 설정을 건너뜁니다."
+      when: slack_webhook_url is not defined or slack_webhook_url == ""
+
+    - name: curl 패키지 설치
+      apt:
+        name: curl
+        state: present
+        update_cache: yes
+      when: slack_webhook_url is defined and slack_webhook_url != ""
+
+    - name: 부팅 알림 스크립트 생성 (vars에서 webhook URL 삽입)
+      template:
+        src: ../files/homelab-boot-notify.sh.j2
+        dest: /usr/local/bin/homelab-boot-notify.sh
+        mode: '0755'
+        owner: root
+        group: root
+      when: slack_webhook_url is defined and slack_webhook_url != ""
+
+    - name: systemd 서비스 파일 복사
+      copy:
+        src: ../files/homelab-boot-notify.service
+        dest: /etc/systemd/system/homelab-boot-notify.service
+        mode: '0644'
+        owner: root
+        group: root
+      when: slack_webhook_url is defined and slack_webhook_url != ""
+
+    - name: systemd 데몬 리로드
+      systemd:
+        daemon_reload: yes
+      when: slack_webhook_url is defined and slack_webhook_url != ""
+
+    - name: 부팅 알림 서비스 활성화
+      systemd:
+        name: homelab-boot-notify
+        enabled: yes
+        state: stopped
+      when: slack_webhook_url is defined and slack_webhook_url != ""
+
+    - name: Slack 설정 완료 메시지
+      debug:
+        msg: "✅ Slack 부팅 알림 서비스가 설정되었습니다. 다음 부팅시부터 알림이 전송됩니다."
+      when: slack_webhook_url is defined and slack_webhook_url != ""

--- a/homelab/01-server-init/vars/main.yml.example
+++ b/homelab/01-server-init/vars/main.yml.example
@@ -8,3 +8,6 @@ target_password: "your_password_here"
 
 # 로컬 공개키 경로
 local_public_key_path: "~/.ssh/id_rsa.pub"
+
+# Slack 알림 설정 (선택사항)
+# slack_webhook_url: "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"


### PR DESCRIPTION
**Summary**

* 홈랩 서버 부팅시 Slack으로 서버 상태를 자동 알림하는 기능 추가
* systemd 서비스를 통한 안정적인 부팅 완료 감지 및 알림 전송
* 선택적 활성화 방식으로 기존 설치 과정에 영향 없음

**Changes**

* systemd 서비스 파일 추가: homelab-boot-notify.service
* Slack 알림 스크립트 템플릿 추가: homelab-boot-notify.sh.j2
* Ansible 플레이북 추가: slack-alert.yml
* deploy.py에 Slack 알림 플레이북 통합
* vars/main.yml.example에 slack_webhook_url 옵션 추가

**Configuration**

* vars/main.yml에 slack_webhook_url 설정시 자동 활성화
* webhook URL 미설정시 해당 단계 스킵하여 기존 워크플로우 유지